### PR TITLE
feat: mover creación de partidos a página dedicada y mejorar visualización de la lista

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,6 +2,7 @@
 import { useAuth } from "./stores/auth";
 import { useRouter } from "vue-router";
 import { ref, onMounted, provide } from 'vue';
+
 const auth = useAuth();
 const router = useRouter();
 const mobileNavOpen = ref(false);
@@ -13,17 +14,22 @@ interface ToastItem {
   type: 'info' | 'success' | 'error';
   timeout: number;
 }
+
 const toasts = ref<ToastItem[]>([]);
+
 function pushToast(message: string, type: ToastItem['type'] = 'info', timeout = 4000) {
   const id = Date.now() + Math.random();
   toasts.value.push({ id, message, type, timeout });
+
   if (timeout > 0) {
     setTimeout(() => removeToast(id), timeout);
   }
 }
+
 function removeToast(id: number) {
   toasts.value = toasts.value.filter(t => t.id !== id);
 }
+
 provide('pushToast', pushToast);
 
 function logout() {
@@ -49,58 +55,96 @@ function linkBaseClasses(active: boolean) {
   ].join(" ");
 }
 </script>
+
 <template>
   <div class="min-h-screen bg-gray-50 text-gray-900">
     <header class="border-b bg-white relative z-50">
       <div class="mx-auto max-w-5xl px-4 py-3 flex items-center gap-4">
-        <span class="text-xl font-bold tracking-tight bg-clip-text text-transparent bg-gradient-to-r from-indigo-600 to-fuchsia-600 select-none">FulbITo</span>
+        <span
+          class="text-xl font-bold tracking-tight bg-clip-text text-transparent bg-gradient-to-r from-indigo-600 to-fuchsia-600 select-none">FulbITo</span>
+
         <!-- Desktop nav -->
         <nav v-if="auth.isAuthenticated" class="hidden sm:flex ml-auto items-center gap-2">
-          <RouterLink to="/" v-slot="{ isActive }"><span :class="linkBaseClasses(isActive)" :aria-current="isActive ? 'page' : undefined">Partidos</span></RouterLink>
-          <RouterLink to="/groups" v-slot="{ isActive }"><span :class="linkBaseClasses(isActive)">Grupos</span></RouterLink>
-          <RouterLink to="/players" v-slot="{ isActive }"><span :class="linkBaseClasses(isActive)">Jugadores</span></RouterLink>
-          <button @click="logout" class="ml-4 inline-flex items-center gap-1 rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-red-500 transition">Salir</button>
+          <RouterLink to="/" v-slot="{ isActive }"><span :class="linkBaseClasses(isActive)"
+              :aria-current="isActive ? 'page' : undefined">Partidos</span></RouterLink>
+          <RouterLink to="/groups" v-slot="{ isActive }">
+            <span :class="linkBaseClasses(isActive)">Grupos</span>
+          </RouterLink>
+
+          <RouterLink to="/players" v-slot="{ isActive }">
+            <span :class="linkBaseClasses(isActive)">Jugadores</span>
+          </RouterLink>
+
+          <button @click="logout"
+            class="ml-4 inline-flex items-center gap-1 rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-red-500 transition">Salir</button>
         </nav>
+
         <nav v-else class="hidden sm:flex ml-auto items-center gap-2">
-          <RouterLink to="/login" v-slot="{ isActive }"><span :class="linkBaseClasses(isActive)">Login</span></RouterLink>
+          <RouterLink to="/login" v-slot="{ isActive }"><span :class="linkBaseClasses(isActive)">Login</span>
+          </RouterLink>
         </nav>
+
         <!-- Mobile toggle -->
-        <button @click="toggleMobileNav" class="sm:hidden ml-auto inline-flex items-center justify-center h-9 w-9 rounded-md border border-gray-300 text-gray-600 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500" :aria-expanded="mobileNavOpen" :aria-label="mobileNavOpen ? 'Cerrar menú' : 'Abrir menú'">
-          <svg v-if="!mobileNavOpen" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16"/></svg>
-          <svg v-else xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+        <button @click="toggleMobileNav"
+          class="sm:hidden ml-auto inline-flex items-center justify-center h-9 w-9 rounded-md border border-gray-300 text-gray-600 hover:bg-gray-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+          :aria-expanded="mobileNavOpen" :aria-label="mobileNavOpen ? 'Cerrar menú' : 'Abrir menú'">
+          <svg v-if="!mobileNavOpen" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24"
+            stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          
+          <svg v-else xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24"
+            stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
         </button>
       </div>
+
       <!-- Mobile menu panel -->
       <transition name="fade">
         <div v-if="mobileNavOpen" class="sm:hidden border-t bg-white shadow-inner">
           <div class="px-4 py-3 flex flex-col gap-2">
             <template v-if="auth.isAuthenticated">
-              <RouterLink to="/" class="w-full" v-slot="{ isActive }"><span :class="linkBaseClasses(isActive) + ' w-full justify-start'">Partidos</span></RouterLink>
-              <RouterLink to="/groups" class="w-full" v-slot="{ isActive }"><span :class="linkBaseClasses(isActive) + ' w-full justify-start'">Grupos</span></RouterLink>
-              <RouterLink to="/players" class="w-full" v-slot="{ isActive }"><span :class="linkBaseClasses(isActive) + ' w-full justify-start'">Jugadores</span></RouterLink>
-              <button @click="logout" class="relative inline-flex items-center rounded-md px-3 py-2 text-sm font-medium transition bg-red-50 text-red-600 hover:bg-red-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-red-500">Salir</button>
+              <RouterLink to="/" class="w-full" v-slot="{ isActive }"><span
+                  :class="linkBaseClasses(isActive) + ' w-full justify-start'">Partidos</span></RouterLink>
+              <RouterLink to="/groups" class="w-full" v-slot="{ isActive }"><span
+                  :class="linkBaseClasses(isActive) + ' w-full justify-start'">Grupos</span></RouterLink>
+              <RouterLink to="/players" class="w-full" v-slot="{ isActive }"><span
+                  :class="linkBaseClasses(isActive) + ' w-full justify-start'">Jugadores</span></RouterLink>
+              <button @click="logout"
+                class="relative inline-flex items-center rounded-md px-3 py-2 text-sm font-medium transition bg-red-50 text-red-600 hover:bg-red-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-red-500">Salir</button>
             </template>
             <template v-else>
-              <RouterLink to="/login" class="w-full" v-slot="{ isActive }"><span :class="linkBaseClasses(isActive) + ' w-full justify-start'">Login</span></RouterLink>
+              <RouterLink to="/login" class="w-full" v-slot="{ isActive }"><span
+                  :class="linkBaseClasses(isActive) + ' w-full justify-start'">Login</span></RouterLink>
             </template>
           </div>
         </div>
       </transition>
     </header>
+
     <main class="mx-auto max-w-5xl px-4 py-6">
       <RouterView />
     </main>
+
     <!-- Toasts -->
-    <TransitionGroup name="toast" tag="div" class="fixed inset-0 flex flex-col items-end gap-2 p-4 pointer-events-none z-[1000]">
-      <div v-for="t in toasts" :key="t.id" role="status" class="w-full sm:w-80 pointer-events-auto select-none overflow-hidden rounded-lg shadow ring-1 ring-black/10 flex items-start gap-3 px-4 py-3 text-sm"
+    <TransitionGroup name="toast" tag="div"
+      class="fixed inset-0 flex flex-col items-end gap-2 p-4 pointer-events-none z-[1000]">
+      <div v-for="t in toasts" :key="t.id" role="status"
+        class="w-full sm:w-80 pointer-events-auto select-none overflow-hidden rounded-lg shadow ring-1 ring-black/10 flex items-start gap-3 px-4 py-3 text-sm"
         :class="[
           t.type === 'success' && 'bg-green-50 text-green-700',
           t.type === 'error' && 'bg-red-50 text-red-700',
           t.type === 'info' && 'bg-white text-gray-700'
         ]">
         <div class="flex-1 leading-snug">{{ t.message }}</div>
-        <button @click="removeToast(t.id)" class="mt-0.5 inline-flex items-center justify-center rounded-md p-1 text-gray-400 hover:bg-black/5 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-indigo-500">
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"/></svg>
+        <button @click="removeToast(t.id)"
+          class="mt-0.5 inline-flex items-center justify-center rounded-md p-1 text-gray-400 hover:bg-black/5 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-indigo-500">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd"
+              d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+              clip-rule="evenodd" />
+          </svg>
         </button>
       </div>
     </TransitionGroup>
@@ -108,8 +152,21 @@ function linkBaseClasses(active: boolean) {
 </template>
 
 <style scoped>
-.toast-enter-from { opacity: 0; transform: translateY(6px) scale(.96); }
-.toast-enter-active { transition: all .22s cubic-bezier(.4,0,.2,1); }
-.toast-leave-to { opacity: 0; transform: translateY(6px) scale(.96); }
-.toast-leave-active { transition: all .18s ease-in; }
+.toast-enter-from {
+  opacity: 0;
+  transform: translateY(6px) scale(.96);
+}
+
+.toast-enter-active {
+  transition: all .22s cubic-bezier(.4, 0, .2, 1);
+}
+
+.toast-leave-to {
+  opacity: 0;
+  transform: translateY(6px) scale(.96);
+}
+
+.toast-leave-active {
+  transition: all .18s ease-in;
+}
 </style>

--- a/src/components/MatchCard.vue
+++ b/src/components/MatchCard.vue
@@ -13,31 +13,45 @@ function remove() { if (props.canDelete) emit('remove', props.match._id as UUID)
 /** Resolve display date choosing scheduledAt fallbacking to legacy fields. */
 function viewDate(m: Match) {
   const d: string | undefined = m.scheduledAt ?? (m as any).date ?? (m as any).createdAt;
-  return d ? new Date(d).toLocaleString() : t('matches.noDate');
+  return d
+    ? new Date(d).toLocaleString('es-AR', {
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false
+    })
+    : t('matches.noDate');
 }
 </script>
 
 <template>
   <div :class="[
-      'p-4 rounded-xl border shadow-sm transition-colors duration-700',
-      match.status === 'finalized' ? 'bg-gray-200' : 'bg-white',
-      highlight && 'bg-green-100 ring-1 ring-green-300'
-    ]">
+    'p-4 rounded-xl border shadow-sm transition-colors duration-700',
+    match.status === 'finalized' ? 'bg-gray-200' : 'bg-white',
+    highlight && 'bg-green-100 ring-1 ring-green-300'
+  ]">
     <div class="flex items-center justify-between">
-      <div class="text-sm opacity-60">{{ viewDate(match) }}</div>
       <div class="flex items-center gap-2">
-        <button
-          v-if="canDelete && match.canEdit"
-          type="button"
-          @click="remove"
-          class="inline-block px-3 py-1.5 text-sm font-medium rounded-md bg-red-600 text-white hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-400/60 transition-colors"
-        >
+        <span class="text-sm opacity-60">{{ viewDate(match) }}</span>
+        <span v-if="match.status === 'finalized'"
+          class="text-xs font-medium px-2 py-0.5 rounded-full bg-gray-400 text-white">
+          {{ t('matches.statusFinalized') }}
+        </span>
+        <span v-else
+          class="text-xs font-medium px-2 py-0.5 rounded-full bg-violet-100 text-violet-700">
+          {{ t('matches.statusUpcoming') }}
+        </span>
+      </div>
+
+      <div class="flex items-center gap-2">
+        <button v-if="canDelete && match.canEdit" type="button" @click="remove"
+          class="inline-block px-3 py-1.5 text-sm font-medium rounded-md bg-red-600 text-white hover:bg-red-500 focus:outline-none focus:ring-2 focus:ring-red-400/60 transition-colors">
           {{ t('matches.delete') }}
         </button>
-        <router-link
-          :to="`/match/${match._id}?group=${selectedGroup || ''}`"
-          class="inline-block px-3 py-1.5 text-sm font-medium rounded-md bg-gray-800 text-white hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-400/50 transition-colors"
-        >
+        <router-link :to="`/match/${match._id}?group=${selectedGroup || ''}`"
+          class="inline-block px-3 py-1.5 text-sm font-medium rounded-md bg-gray-800 text-white hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-400/50 transition-colors">
           {{ t('matches.open') }}
         </router-link>
       </div>
@@ -45,5 +59,4 @@ function viewDate(m: Match) {
   </div>
 </template>
 
-<style scoped>
-</style>
+<style scoped></style>

--- a/src/localizations/index.ts
+++ b/src/localizations/index.ts
@@ -78,6 +78,9 @@ const es: Dictionary = {
     noDate: "Sin fecha",
     deleteError: "No se pudo eliminar el partido",
     matchesTitle: "Partidos",
+    backToList: "Volver a partidos",
+    statusFinalized: "Finalizado",
+    statusUpcoming: "Próximo",
   },
   matchDetail: {
     loading: "Cargando partido…",

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import MatchesPage from '../views/MatchesPage.vue'
+import CreateMatchPage from '../views/CreateMatchPage.vue'
 import MatchDetailPage from '../views/MatchDetailPage.vue'
 import GroupsPage from '../views/GroupsPage.vue'
 import PlayersPage from '../views/PlayersPage.vue'
@@ -14,6 +15,7 @@ const routes = [
   { path: '/register', name: 'register', component: RegisterPage },
   { path: '/forgot', name: 'forgot', component: ForgotPasswordPage },
   { path: '/', name: 'matches', component: MatchesPage, meta: { requiresAuth: true } },
+  { path: '/matches/new', name: 'create-match', component: CreateMatchPage, meta: { requiresAuth: true } },
   { path: '/match/:id', name: 'match-detail', component: MatchDetailPage, props: true, meta: { requiresAuth: true } },
   { path: '/groups', name: 'groups', component: GroupsPage, meta: { requiresAuth: true } },
   { path: '/players', name: 'players', component: PlayersPage, meta: { requiresAuth: true } },

--- a/src/views/CreateMatchPage.vue
+++ b/src/views/CreateMatchPage.vue
@@ -1,0 +1,133 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from "vue";
+import { useRouter } from "vue-router";
+import { t } from '@/localizations';
+import CenteredLoader from '../components/CenteredLoader.vue';
+import { useGroups } from "../stores/groups";
+import { usePlayers } from "../stores/players";
+import { listByGroup as apiListByGroup, create as apiCreateMatch } from "../lib/matches.service";
+import type { UUID, MatchesGroupResponse } from "../types";
+
+const router = useRouter();
+const groups = useGroups();
+const players = usePlayers();
+const loading = ref(true);
+
+onMounted(async () => {
+  loading.value = true;
+  try {
+    await Promise.all([groups.fetch(), players.fetch()]);
+  } finally { loading.value = false; }
+
+  if (groups.items.length === 1) {
+    selectedGroup.value = groups?.items[0]?._id ?? "";
+  }
+});
+
+function nowLocalForInput() {
+  const d = new Date();
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(
+    d.getHours()
+  )}:${pad(d.getMinutes())}`;
+}
+
+const selectedGroup = ref<UUID | "">("");
+const selectedPlayers = ref<UUID[]>([]);
+const when = ref<string>(nowLocalForInput());
+const meta = ref<MatchesGroupResponse['meta'] | null>(null);
+
+const groupMemberIds = computed<string[]>(() => {
+  const g = groups.items.find((x) => x._id === selectedGroup.value);
+  if (!g) return [];
+  return ((g as any).members ?? (g as any).players ?? []).map((id: any) =>
+    String(id)
+  );
+});
+
+const groupMembers = computed(() => {
+  const set = new Set(groupMemberIds.value);
+  return players.items.filter((p) => set.has(String(p._id)));
+});
+
+async function onGroupChange() {
+  const set = new Set(groupMemberIds.value);
+  selectedPlayers.value = selectedPlayers.value.filter((id) => set.has(String(id)));
+
+  if (selectedGroup.value) {
+    const resp = await apiListByGroup(selectedGroup.value as UUID);
+    meta.value = resp.meta;
+  } else {
+    meta.value = null;
+  }
+}
+
+async function createMatch() {
+  if (!selectedGroup.value || selectedPlayers.value.length < 2) return;
+
+  const scheduledAt = when.value ? new Date(when.value).toISOString() : undefined;
+
+  await apiCreateMatch(
+    selectedGroup.value as UUID,
+    selectedPlayers.value,
+    scheduledAt
+  );
+
+  router.push({ name: 'matches' });
+}
+</script>
+
+<template>
+  <CenteredLoader v-if="loading" :label="t('matches.loading')" />
+  <div v-else class="space-y-6">
+    <div class="flex items-center gap-3">
+      <button @click="router.back()" class="text-sm text-gray-500 hover:text-gray-800 flex items-center gap-1">
+        ← {{ t('matches.backToList') }}
+      </button>
+    </div>
+
+    <h1 class="text-2xl font-semibold">{{ t('matches.create') }}</h1>
+
+    <div class="bg-white p-4 rounded-xl border space-y-4">
+      <!-- Group + Date + Create Button -->
+      <div class="grid md:grid-cols-[1fr,auto,auto] gap-3 items-center">
+        <select v-model="selectedGroup" @change="onGroupChange" class="border rounded px-3 py-2">
+          <option value="" disabled>{{ t('matches.chooseGroup') }}</option>
+          <option v-for="g in groups.items" :key="g._id" :value="g._id">
+            {{ g.name }}
+          </option>
+        </select>
+
+        <input v-model="when" type="datetime-local" class="border rounded px-3 py-2" />
+
+        <button
+          class="px-4 py-2 rounded text-white disabled:opacity-50"
+          :class="meta?.canCreate ? 'bg-black hover:bg-gray-800' : 'bg-gray-400 cursor-not-allowed'"
+          :disabled="!selectedGroup || selectedPlayers.length < 2 || !meta?.canCreate"
+          :title="!meta?.canCreate ? t('matches.noPermissionCreate') : ''"
+          @click="createMatch">
+          {{ t('matches.create') }}
+        </button>
+      </div>
+
+      <!-- Player checkboxes -->
+      <TransitionGroup name="groupMembers" tag="div" class="space-y-3" appear>
+        <div v-if="selectedGroup" class="flex flex-wrap gap-3">
+          <label
+            v-for="p in groupMembers"
+            :key="p._id"
+            class="inline-flex items-center gap-2 border rounded px-3 py-2 cursor-pointer hover:bg-gray-50">
+            <input type="checkbox" :value="p._id" v-model="selectedPlayers" />
+            <span>{{ p.name }}</span>
+          </label>
+
+          <p v-if="groupMembers.length === 0" class="text-sm text-gray-500">
+            {{ t('matches.groupNoPlayers') }}
+          </p>
+        </div>
+
+        <p v-else class="text-sm text-gray-500">{{ t('matches.selectGroupSeePlayers') }}</p>
+      </TransitionGroup>
+    </div>
+  </div>
+</template>

--- a/src/views/MatchDetailPage.vue
+++ b/src/views/MatchDetailPage.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { onMounted, ref, computed } from "vue";
 import { t } from '@/localizations';
-import { useRoute } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 import * as matchesApi from "../lib/matches.service";
 import { usePlayers } from "../stores/players";
 import type { UUID, Match, RatingChange, MatchesGroupResponse, MyVotesResponse } from "../types";
@@ -22,6 +22,7 @@ const editingResult = ref(false);
 const editScoreA = ref<number | null>(null);
 const editScoreB = ref<number | null>(null);
 const updateResultError = ref<string | null>(null);
+const router = useRouter();
 
 /**
  * Fetch match (within its group list) & hydrate votes on mount.
@@ -57,7 +58,7 @@ async function hydrateMyVotes() {
     if (mv.ratingApplied) current.value.ratingApplied = true as any;
     if (mv.ratingChanges) current.value.ratingChanges = mv.ratingChanges as any;
   } catch (e) {
-  console.warn(t('matchDetail.voteError'), e);
+    console.warn(t('matchDetail.voteError'), e);
   }
 }
 
@@ -253,13 +254,13 @@ async function votePlayer(playerId: UUID, vote: 'up' | 'neutral' | 'down') {
   try {
     await matchesApi.voteMatchPlayer(current.value._id, playerId, vote);
     // Actualizamos myVotes localmente para no requerir refetch inmediato
-  if (!current.value.myVotes) current.value.myVotes = [] as any;
-  const mv = current.value.myVotes as UUID[];
-  if (!mv.includes(playerId)) mv.push(playerId);
+    if (!current.value.myVotes) current.value.myVotes = [] as any;
+    const mv = current.value.myVotes as UUID[];
+    if (!mv.includes(playerId)) mv.push(playerId);
     await hydrateMyVotes();
   } catch (e: any) {
     console.error(e);
-  alert(e?.message || t('matchDetail.voteError'));
+    alert(e?.message || t('matchDetail.voteError'));
   }
 }
 
@@ -281,8 +282,8 @@ async function applyRatingsNow() {
     localChanges.value = res.changes;
     await hydrateMyVotes();
   } catch (e: any) {
-  console.error(e);
-  alert(e?.message || t('matchDetail.applyError'));
+    console.error(e);
+    alert(e?.message || t('matchDetail.applyError'));
   } finally {
     applyingRatings.value = false;
   }
@@ -290,222 +291,225 @@ async function applyRatingsNow() {
 </script>
 
 <template>
-  <div class="space-y-6">
-      <div v-if="loading" class="fixed inset-0 flex items-center justify-center px-4">
-        <div class="flex flex-col items-center gap-4 text-center">
-          <div class="relative w-14 h-14">
-            <span class="absolute inset-0 rounded-full border-4 border-indigo-200"></span>
-            <span class="absolute inset-0 rounded-full border-4 border-indigo-600 border-t-transparent animate-spin"></span>
-          </div>
-          <p class="text-sm font-medium text-gray-700">{{ t('matchDetail.loading') }}</p>
-        </div>
-      </div>
-      <template v-if="!loading && current">
-    <div class="flex items-center gap-3">
-  <h1 class="text-2xl font-semibold">{{ t('matchDetail.title') }}</h1>
-      <button
-        class="ml-auto px-4 py-2 rounded bg-black text-white disabled:opacity-50"
-          :disabled="loadingGen || !current || isFinalized || !current.canEdit"
-        @click="autoTeams"
-        v-if="current.canEdit"
-      >
-          {{ loadingGen ? t('matchDetail.generating') : t('matchDetail.generateTeams')}}
+  <div>
+    <div class="mb-4">
+      <button @click="router.back()" class="text-sm text-gray-500 hover:text-gray-800 flex items-center gap-1">
+        ← {{ t('matches.backToList') }}
       </button>
     </div>
 
-    <div v-if="hasTeams" class="grid md:grid-cols-2 gap-4">
-      <div class="bg-white p-4 rounded-xl shadow border space-y-2">
-  <h2 class="font-medium">{{ t('matchDetail.teamA') }}</h2>
-        <ul class="space-y-1">
-          <li v-for="p in teamA" :key="p.id" class="flex items-center gap-2">
-            <span class="w-2 h-2 rounded-full bg-gray-400" />
-            <span>{{ p.name }}</span>
-          </li>
-        </ul>
-      </div>
-      <div class="bg-white p-4 rounded-xl shadow border space-y-2">
-  <h2 class="font-medium">{{ t('matchDetail.teamB') }}</h2>
-        <ul class="space-y-1">
-          <li v-for="p in teamB" :key="p.id" class="flex items-center gap-2">
-            <span class="w-2 h-2 rounded-full bg-gray-400" />
-            <span>{{ p.name }}</span>
-          </li>
-        </ul>
-      </div>
-    </div>
-
-    <!-- 2) Si TODAVÍA NO hay equipos, muestro "Jugadores anotados" -->
-    <div v-else class="bg-white p-4 rounded-xl shadow border space-y-2">
-  <h2 class="font-medium">{{ t('matchDetail.signedPlayers') }}</h2>
-      <p class="text-sm text-gray-500" v-if="participants.length === 0">
-  {{ t('matchDetail.noSignedPlayers') }}
-      </p>
-      <ul v-else class="grid sm:grid-cols-2 lg:grid-cols-3 gap-2">
-        <li
-          v-for="p in participants"
-          :key="p.id"
-          class="flex items-center gap-2 border rounded px-3 py-2"
-        >
-          <span class="w-2 h-2 rounded-full bg-gray-400" />
-          <span>{{ p.name }}</span>
-        </li>
-      </ul>
-    </div>
-
-    <!-- ─────── Resultado / Finalización ─────── -->
-    <div class="bg-white p-4 rounded-xl shadow border">
-  <h2 class="font-medium mb-3">{{ t('matchDetail.result') }}</h2>
-
-      <!-- ya finalizado -->
-      <template v-if="isFinalized">
-        <!-- View mode -->
-        <template v-if="!editingResult">
-          <div class="flex items-center gap-3 flex-wrap">
-            <div class="text-lg font-semibold">
-              {{ finalScore.a }} — {{ finalScore.b }}
-            </div>
-            <button
-              v-if="current?.canEdit && !ratingApplied"
-              @click="startEditResult"
-              class="text-xs px-3 py-1 rounded border bg-white hover:bg-gray-50"
-            >{{ t('matchDetail.editResult') }}</button>
-          </div>
-          <div class="text-xs opacity-60" v-if="finalizedAt">
-            {{ t('matchDetail.finalizedAt') }} {{ finalizedAt }}
-          </div>
-        </template>
-        <!-- Edit mode -->
-        <template v-else>
-          <div class="flex items-center gap-2">
-            <input type="number" min="0" class="border rounded px-2 py-1 w-20" v-model.number="editScoreA" />
-            <span class="opacity-60">—</span>
-            <input type="number" min="0" class="border rounded px-2 py-1 w-20" v-model.number="editScoreB" />
-            <button @click="saveEditedResult" class="px-3 py-1 rounded bg-black text-white text-xs">{{ t('matchDetail.updateResult') }}</button>
-            <button @click="cancelEditResult" class="px-3 py-1 rounded border text-xs">{{ t('matchDetail.cancel') }}</button>
-          </div>
-          <p v-if="updateResultError" class="text-xs text-red-600 mt-2">{{ updateResultError }}</p>
-        </template>
-        <!-- View mode -->
-        <template v-if="!editingResult">
-          <div class="flex items-center gap-3 flex-wrap">
-            <div class="text-lg font-semibold">
-              {{ finalScore.a }} — {{ finalScore.b }}
-            </div>
-            <button
-              v-if="current?.canEdit && !ratingApplied"
-              @click="startEditResult"
-              class="text-xs px-3 py-1 rounded border bg-white hover:bg-gray-50"
-            >{{ t('matchDetail.editResult') }}</button>
-          </div>
-          <div class="text-xs opacity-60" v-if="finalizedAt">
-            {{ t('matchDetail.finalizedAt') }} {{ finalizedAt }}
-          </div>
-        </template>
-        <!-- Edit mode -->
-        <template v-else>
-          <div class="flex items-center gap-2">
-            <input type="number" min="0" class="border rounded px-2 py-1 w-20" v-model.number="editScoreA" />
-            <span class="opacity-60">—</span>
-            <input type="number" min="0" class="border rounded px-2 py-1 w-20" v-model.number="editScoreB" />
-            <button @click="saveEditedResult" class="px-3 py-1 rounded bg-black text-white text-xs">{{ t('matchDetail.updateResult') }}</button>
-            <button @click="cancelEditResult" class="px-3 py-1 rounded border text-xs">{{ t('matchDetail.cancel') }}</button>
-          </div>
-          <p v-if="updateResultError" class="text-xs text-red-600 mt-2">{{ updateResultError }}</p>
-        </template>
-      </template>
-
-      <!-- todavía no finalizado -->
-      <template v-else>
-        <div class="flex items-center gap-2">
-          <input
-            type="number"
-            class="border rounded px-2 py-1 w-20"
-            v-model.number="scoreA"
-            min="0"
-          />
-          <span class="opacity-60">—</span>
-          <input
-            type="number"
-            class="border rounded px-2 py-1 w-20"
-            v-model.number="scoreB"
-            min="0"
-          />
-          <button
-            @click="finish"
-            class="ml-3 px-4 py-2 rounded bg-black text-white disabled:opacity-50"
-            :disabled="isFinalized || !hasTeams || !current?.canEdit"
-          >
-            {{ t('matchDetail.finalize') }}
-          </button>
+    <div v-if="loading" class="fixed inset-0 flex items-center justify-center px-4">
+      <div class="flex flex-col items-center gap-4 text-center">
+        <div class="relative w-14 h-14">
+          <span class="absolute inset-0 rounded-full border-4 border-indigo-200"></span>
+          <span
+            class="absolute inset-0 rounded-full border-4 border-indigo-600 border-t-transparent animate-spin"></span>
         </div>
-  <p v-if="!hasTeams" class="mt-2 text-xs text-red-600">{{ t('matchDetail.needTeamsFirst') }}</p>
-      </template>
+        <p class="text-sm font-medium text-gray-700">{{ t('matchDetail.loading') }}</p>
+      </div>
     </div>
 
-    <!-- ─────── Feedback / Calificación Jugadores ─────── -->
-    <div v-if="isFinalized" class="bg-white p-4 rounded-xl shadow border space-y-4">
-      <template v-if="!ratingApplied">
-  <h2 class="font-medium flex items-center gap-2">{{ t('matchDetail.ratePlayers') }}
-          <span class="text-xs font-normal text-gray-500" v-if="playersForRating.length">({{ playersForRating.length }} pendientes)</span>
-        </h2>
-        <p v-if="playersForRating.length === 0" class="text-sm text-gray-500">
-          {{ t('matchDetail.allRated') }}
+    <template v-if="!loading && current">
+      <div class="flex items-center gap-3">
+        <h1 class="text-2xl font-semibold mb-2">{{ t('matchDetail.title') }}</h1>
+        <button class="ml-auto px-4 py-2 rounded bg-black text-white disabled:opacity-50"
+          :disabled="loadingGen || !current || isFinalized || !current.canEdit" @click="autoTeams"
+          v-if="current.canEdit">
+          {{ loadingGen ? t('matchDetail.generating') : t('matchDetail.generateTeams') }}
+        </button>
+      </div>
+
+      <div v-if="hasTeams" class="grid md:grid-cols-2 gap-4">
+        <div class="bg-white p-4 rounded-xl shadow border space-y-2">
+          <h2 class="font-medium">{{ t('matchDetail.teamA') }}</h2>
+          <ul class="space-y-1">
+            <li v-for="p in teamA" :key="p.id" class="flex items-center gap-2">
+              <span class="w-2 h-2 rounded-full bg-gray-400" />
+              <span>{{ p.name }}</span>
+            </li>
+          </ul>
+        </div>
+        <div class="bg-white p-4 rounded-xl shadow border space-y-2">
+          <h2 class="font-medium">{{ t('matchDetail.teamB') }}</h2>
+          <ul class="space-y-1">
+            <li v-for="p in teamB" :key="p.id" class="flex items-center gap-2">
+              <span class="w-2 h-2 rounded-full bg-gray-400" />
+              <span>{{ p.name }}</span>
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      <!-- 2) Si TODAVÍA NO hay equipos, muestro "Jugadores anotados" -->
+      <div v-else class="bg-white p-4 rounded-xl shadow border space-y-2">
+        <h2 class="font-medium">{{ t('matchDetail.signedPlayers') }}</h2>
+        <p class="text-sm text-gray-500" v-if="participants.length === 0">
+          {{ t('matchDetail.noSignedPlayers') }}
         </p>
         <ul v-else class="grid sm:grid-cols-2 lg:grid-cols-3 gap-2">
-          <li v-for="p in playersForRating" :key="p.id" class="flex items-center justify-between gap-2 border rounded px-3 py-2">
-            <span class="truncate">{{ p.name }}</span>
-            <div class="flex items-center gap-1">
-              <button @click="votePlayer(p.id as UUID, 'down')" class="w-8 h-8 flex items-center justify-center rounded bg-red-100 text-red-600 hover:bg-red-200" :title="t('matchDetail.bad')">👎</button>
-              <button @click="votePlayer(p.id as UUID, 'neutral')" class="w-8 h-8 flex items-center justify-center rounded bg-gray-100 text-gray-600 hover:bg-gray-200" :title="t('matchDetail.neutral')">😐</button>
-              <button @click="votePlayer(p.id as UUID, 'up')" class="w-8 h-8 flex items-center justify-center rounded bg-green-100 text-green-600 hover:bg-green-200" :title="t('matchDetail.good')">👍</button>
-            </div>
+          <li v-for="p in participants" :key="p.id" class="flex items-center gap-2 border rounded px-3 py-2">
+            <span class="w-2 h-2 rounded-full bg-gray-400" />
+            <span>{{ p.name }}</span>
           </li>
         </ul>
-        <div class="pt-2 border-t space-y-2">
-          <button
-            v-if="canApply && playersForRating.length === 0"
-            @click="applyRatingsNow"
-            :disabled="applyingRatings"
-            class="px-4 py-2 rounded bg-black text-white disabled:opacity-40"
-          >
-            {{ applyingRatings ? t('matchDetail.applying') : t('matchDetail.apply') }}
-          </button>
-          <p v-else-if="playersForRating.length === 0" class="text-xs text-gray-500">
-            {{ t('matchDetail.waitingOrganizer') }}
+      </div>
+
+      <!-- ─────── Resultado / Finalización ─────── -->
+      <div class="bg-white p-4 rounded-xl shadow border mt-6">
+        <h2 class="font-medium mb-3">{{ t('matchDetail.result') }}</h2>
+
+        <!-- ya finalizado -->
+        <template v-if="isFinalized">
+          <!-- View mode -->
+          <template v-if="!editingResult">
+            <div class="flex items-center gap-3 flex-wrap">
+              <div class="text-lg font-semibold">
+                {{ finalScore.a }} — {{ finalScore.b }}
+              </div>
+              <button v-if="current?.canEdit && !ratingApplied" @click="startEditResult"
+                class="text-xs px-3 py-1 rounded border bg-white hover:bg-gray-50">{{ t('matchDetail.editResult')
+                }}</button>
+            </div>
+            <div class="text-xs opacity-60" v-if="finalizedAt">
+              {{ t('matchDetail.finalizedAt') }} {{ finalizedAt }}
+            </div>
+          </template>
+          <!-- Edit mode -->
+          <template v-else>
+            <div class="flex items-center gap-2">
+              <input type="number" min="0" class="border rounded px-2 py-1 w-20" v-model.number="editScoreA" />
+              <span class="opacity-60">—</span>
+              <input type="number" min="0" class="border rounded px-2 py-1 w-20" v-model.number="editScoreB" />
+              <button @click="saveEditedResult" class="px-3 py-1 rounded bg-black text-white text-xs">{{
+                t('matchDetail.updateResult') }}</button>
+              <button @click="cancelEditResult" class="px-3 py-1 rounded border text-xs">{{ t('matchDetail.cancel')
+              }}</button>
+            </div>
+            <p v-if="updateResultError" class="text-xs text-red-600 mt-2">{{ updateResultError }}</p>
+          </template>
+          <!-- View mode -->
+          <template v-if="!editingResult">
+            <div class="flex items-center gap-3 flex-wrap">
+              <div class="text-lg font-semibold">
+                {{ finalScore.a }} — {{ finalScore.b }}
+              </div>
+              <button v-if="current?.canEdit && !ratingApplied" @click="startEditResult"
+                class="text-xs px-3 py-1 rounded border bg-white hover:bg-gray-50">{{ t('matchDetail.editResult')
+                }}</button>
+            </div>
+            <div class="text-xs opacity-60" v-if="finalizedAt">
+              {{ t('matchDetail.finalizedAt') }} {{ finalizedAt }}
+            </div>
+          </template>
+          <!-- Edit mode -->
+          <template v-else>
+            <div class="flex items-center gap-2">
+              <input type="number" min="0" class="border rounded px-2 py-1 w-20" v-model.number="editScoreA" />
+              <span class="opacity-60">—</span>
+              <input type="number" min="0" class="border rounded px-2 py-1 w-20" v-model.number="editScoreB" />
+              <button @click="saveEditedResult" class="px-3 py-1 rounded bg-black text-white text-xs">{{
+                t('matchDetail.updateResult') }}</button>
+              <button @click="cancelEditResult" class="px-3 py-1 rounded border text-xs">{{ t('matchDetail.cancel')
+              }}</button>
+            </div>
+            <p v-if="updateResultError" class="text-xs text-red-600 mt-2">{{ updateResultError }}</p>
+          </template>
+        </template>
+
+        <!-- todavía no finalizado -->
+        <template v-else>
+          <div class="flex items-center gap-2">
+            <input type="number" class="border rounded px-2 py-1 w-20" v-model.number="scoreA" min="0" />
+            <span class="opacity-60">—</span>
+            <input type="number" class="border rounded px-2 py-1 w-20" v-model.number="scoreB" min="0" />
+            <button @click="finish" class="ml-3 px-4 py-2 rounded bg-black text-white disabled:opacity-50"
+              :disabled="isFinalized || !hasTeams || !current?.canEdit">
+              {{ t('matchDetail.finalize') }}
+            </button>
+          </div>
+          <p v-if="!hasTeams" class="mt-2 text-xs text-red-600">{{ t('matchDetail.needTeamsFirst') }}</p>
+        </template>
+      </div>
+
+      <!-- ─────── Feedback / Calificación Jugadores ─────── -->
+      <div v-if="isFinalized" class="bg-white p-4 rounded-xl shadow border space-y-4">
+        <template v-if="!ratingApplied">
+          <h2 class="font-medium flex items-center gap-2">{{ t('matchDetail.ratePlayers') }}
+            <span class="text-xs font-normal text-gray-500" v-if="playersForRating.length">({{ playersForRating.length
+            }} pendientes)</span>
+          </h2>
+          <p v-if="playersForRating.length === 0" class="text-sm text-gray-500">
+            {{ t('matchDetail.allRated') }}
           </p>
-          <p v-else class="text-xs text-gray-500">
-            {{ t('matchDetail.pendingYourVotes') }}
-          </p>
-        </div>
-      </template>
-      <template v-else>
-  <h2 class="font-medium">{{ t('matchDetail.ratingChanges') }}</h2>
-  <p class="text-sm text-gray-500" v-if="(current?.ratingChanges?.length || 0) === 0">{{ t('matchDetail.noChanges') }}</p>
-        <table v-else class="w-full text-sm border-t">
-          <thead>
-            <tr class="text-left">
-              <th class="py-2 pr-2">{{ t('matchDetail.colPlayer') }}</th>
-              <th class="py-2 pr-2">{{ t('matchDetail.colBefore') }}</th>
-              <th class="py-2 pr-2">{{ t('matchDetail.colAfter') }}</th>
-              <th class="py-2 pr-2">{{ t('matchDetail.colDelta') }}</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="c in (current?.ratingChanges || localChanges)" :key="c.playerId" class="border-t">
-              <td class="py-1 pr-2">{{ players.nameById(c.playerId) }}</td>
-              <td class="py-1 pr-2">{{ c.before }}</td>
-              <td class="py-1 pr-2">{{ c.after }}</td>
-              <td class="py-1 pr-2 font-medium" :class="c.delta>0 ? 'text-green-600' : c.delta<0 ? 'text-red-600' : 'text-gray-500'">{{ c.delta>0? '+'+c.delta : c.delta }}</td>
-            </tr>
-          </tbody>
-        </table>
-      </template>
-    </div>
+          <ul v-else class="grid sm:grid-cols-2 lg:grid-cols-3 gap-2">
+            <li v-for="p in playersForRating" :key="p.id"
+              class="flex items-center justify-between gap-2 border rounded px-3 py-2">
+              <span class="truncate">{{ p.name }}</span>
+              <div class="flex items-center gap-1">
+                <button @click="votePlayer(p.id as UUID, 'down')"
+                  class="w-8 h-8 flex items-center justify-center rounded bg-red-100 text-red-600 hover:bg-red-200"
+                  :title="t('matchDetail.bad')">👎</button>
+                <button @click="votePlayer(p.id as UUID, 'neutral')"
+                  class="w-8 h-8 flex items-center justify-center rounded bg-gray-100 text-gray-600 hover:bg-gray-200"
+                  :title="t('matchDetail.neutral')">😐</button>
+                <button @click="votePlayer(p.id as UUID, 'up')"
+                  class="w-8 h-8 flex items-center justify-center rounded bg-green-100 text-green-600 hover:bg-green-200"
+                  :title="t('matchDetail.good')">👍</button>
+              </div>
+            </li>
+          </ul>
+          <div class="pt-2 border-t space-y-2">
+            <button v-if="canApply && playersForRating.length === 0" @click="applyRatingsNow"
+              :disabled="applyingRatings" class="px-4 py-2 rounded bg-black text-white disabled:opacity-40">
+              {{ applyingRatings ? t('matchDetail.applying') : t('matchDetail.apply') }}
+            </button>
+            <p v-else-if="playersForRating.length === 0" class="text-xs text-gray-500">
+              {{ t('matchDetail.waitingOrganizer') }}
+            </p>
+            <p v-else class="text-xs text-gray-500">
+              {{ t('matchDetail.pendingYourVotes') }}
+            </p>
+          </div>
+        </template>
+        <template v-else>
+          <h2 class="font-medium">{{ t('matchDetail.ratingChanges') }}</h2>
+          <p class="text-sm text-gray-500" v-if="(current?.ratingChanges?.length || 0) === 0">{{
+            t('matchDetail.noChanges') }}</p>
+          <table v-else class="w-full text-sm border-t">
+            <thead>
+              <tr class="text-left">
+                <th class="py-2 pr-2">{{ t('matchDetail.colPlayer') }}</th>
+                <th class="py-2 pr-2">{{ t('matchDetail.colBefore') }}</th>
+                <th class="py-2 pr-2">{{ t('matchDetail.colAfter') }}</th>
+                <th class="py-2 pr-2">{{ t('matchDetail.colDelta') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="c in (current?.ratingChanges || localChanges)" :key="c.playerId" class="border-t">
+                <td class="py-1 pr-2">{{ players.nameById(c.playerId) }}</td>
+                <td class="py-1 pr-2">{{ c.before }}</td>
+                <td class="py-1 pr-2">{{ c.after }}</td>
+                <td class="py-1 pr-2 font-medium"
+                  :class="c.delta > 0 ? 'text-green-600' : c.delta < 0 ? 'text-red-600' : 'text-gray-500'">{{ c.delta >
+                    0 ?
+                    '+' + c.delta : c.delta }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </template>
+      </div>
     </template>
   </div>
 </template>
 
 <style scoped>
-@keyframes spin { to { transform: rotate(360deg); } }
-.animate-spin { animation: spin 0.9s linear infinite; }
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.animate-spin {
+  animation: spin 0.9s linear infinite;
+}
 </style>

--- a/src/views/MatchesPage.vue
+++ b/src/views/MatchesPage.vue
@@ -1,75 +1,45 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from "vue";
+import { ref, onMounted, watch } from "vue";
+import { useRouter } from "vue-router";
 import { t } from '@/localizations';
 import CenteredLoader from '../components/CenteredLoader.vue';
 import MatchCard from '../components/MatchCard.vue';
 import { useGroups } from "../stores/groups";
-import { usePlayers } from "../stores/players";
-import { listByGroup as apiListByGroup, create as apiCreateMatch, deleteMatch as apiDeleteMatch } from "../lib/matches.service";
-import type { UUID, Match, MatchesGroupResponse } from "../types";
+import { listByGroup as apiListByGroup, deleteMatch as apiDeleteMatch } from "../lib/matches.service";
+import type { UUID, Match } from "../types";
 
+const router = useRouter();
 const groups = useGroups();
-const players = usePlayers();
 const loading = ref(true);
 
 /**
- * Initial fetch for groups & players on mount.
- * @returns {Promise<void>} Resolves when both stores have finished loading.
+ * Initial fetch for groups on mount.
  */
 onMounted(async () => {
   loading.value = true;
-  try {
-    await Promise.all([groups.fetch(), players.fetch()]);
-  } finally { loading.value = false; }
-});
 
-/**
- * Build current datetime-local string (YYYY-MM-DDTHH:mm) for input default.
- * @returns {string} A formatted datetime-local compatible value.
- */
-function nowLocalForInput() {
-  const d = new Date();
-  const pad = (n: number) => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(
-    d.getHours()
-  )}:${pad(d.getMinutes())}`;
-}
+  try {
+    await groups.fetch();
+  } finally {
+    loading.value = false;
+  }
+
+  if (groups.items.length === 1) {
+    selectedGroup.value = groups?.items[0]?._id ?? "";
+  }
+});
 
 const selectedGroup = ref<UUID | "">("");
-const selectedPlayers = ref<UUID[]>([]);
-const when = ref<string>(nowLocalForInput());
 const items = ref<Match[]>([]);
-const meta = ref<MatchesGroupResponse['meta'] | null>(null);
 const highlights = ref<Record<string, boolean>>({});
 
-const groupMemberIds = computed<string[]>(() => {
-  const g = groups.items.find((x) => x._id === selectedGroup.value);
-  if (!g) return [];
-  return ((g as any).members ?? (g as any).players ?? []).map((id: any) =>
-    String(id)
-  );
-});
-
-const groupMembers = computed(() => {
-  const set = new Set(groupMemberIds.value);
-  return players.items.filter((p) => set.has(String(p._id)));
-});
-
 /**
- * React to group selection changes: prune selected players not in group and fetch matches.
- * @param {UUID | ""} gid Group id chosen by the user (empty string means none).
- * @returns {Promise<void>} Resolves after matches (if any) are fetched.
+ * React to group selection changes: fetch matches for the selected group.
  */
 watch(selectedGroup, async (gid) => {
-  const set = new Set(groupMemberIds.value);
-  selectedPlayers.value = selectedPlayers.value.filter((id) =>
-    set.has(String(id))
-  );
-
   items.value = [];
   if (gid) {
     const resp = await apiListByGroup(gid as UUID);
-    meta.value = resp.meta;
     const list = resp.matches;
     items.value = [...list].sort((a, b) => {
       const da = new Date((a.scheduledAt ?? (a as any).createdAt) || 0).getTime();
@@ -80,33 +50,7 @@ watch(selectedGroup, async (gid) => {
 });
 
 /**
- * Create a new match with chosen players & optional scheduled timestamp.
- * Highlights the created card briefly.
- * Preconditions: selectedGroup set and at least two players chosen.
- * @returns {Promise<void>} Resolves after creation and UI state updates.
- */
-async function createMatch() {
-  if (!selectedGroup.value || selectedPlayers.value.length < 2) return;
-
-  const scheduledAt = when.value ? new Date(when.value).toISOString() : undefined;
-
-  const m = await apiCreateMatch(
-    selectedGroup.value as UUID,
-    selectedPlayers.value,
-    scheduledAt
-  );
-
-  items.value.unshift(m);
-  highlights.value[m._id] = true;
-  setTimeout(() => { delete highlights.value[m._id]; }, 600);
-  selectedPlayers.value = [];
-}
-
-
-/**
  * Delete match by id and remove from list; shows alert on failure.
- * @param {UUID} id Match identifier to delete.
- * @returns {Promise<void>}
  */
 async function removeMatch(id: UUID) {
   try {
@@ -122,46 +66,23 @@ async function removeMatch(id: UUID) {
 <template>
   <CenteredLoader v-if="loading" :label="t('matches.loading')" />
   <div v-else class="space-y-6">
-    <div class="bg-white p-4 rounded-xl border space-y-3">
-      <div class="grid md:grid-cols-[1fr,auto,auto] gap-3 items-center">
-        <!-- Grupo -->
-        <select v-model="selectedGroup" class="border rounded px-3 py-2">
-          <option value="" disabled>{{ t('matches.chooseGroup') }}</option>
-          <option v-for="g in groups.items" :key="g._id" :value="g._id">
-            {{ g.name }}
-          </option>
-        </select>
+    <!-- Group selector and create button -->
+    <div class="flex flex-wrap items-center gap-3">
+      <select v-model="selectedGroup" class="border rounded px-3 py-2 flex-1 min-w-0">
+        <option value="" disabled>{{ t('matches.chooseGroup') }}</option>
 
-        <!-- Fecha (opcional) -->
-        <input v-model="when" type="datetime-local" class="border rounded px-3 py-2" />
+        <option v-for="g in groups.items" :key="g._id" :value="g._id">
+          {{ g.name }}
+        </option>
+      </select>
 
-        <!-- Crear -->
-        <button class="px-4 py-2 rounded text-white disabled:opacity-50"
-          :class="meta?.canCreate ? 'bg-black hover:bg-gray-800' : 'bg-gray-400 cursor-not-allowed'"
-          :disabled="!selectedGroup || selectedPlayers.length < 2 || !meta?.canCreate" @click="createMatch" title=""
-          :data-tip="!meta?.canCreate ? 'No tenés permiso para crear partidos en este grupo' : ''">
-          {{ t('matches.create') }}
-        </button>
-      </div>
-
-      <!-- Checkboxes de jugadores del grupo -->
-      <TransitionGroup name="groupMembers" tag="div" class="space-y-3" appear>
-        <div v-if="selectedGroup" class="flex flex-wrap gap-3">
-          <label v-for="p in groupMembers" :key="p._id" class="inline-flex items-center gap-2 border rounded px-3 py-2">
-            <input type="checkbox" :value="p._id" v-model="selectedPlayers" />
-
-            <span>{{ p.name }}</span>
-          </label>
-
-          <p v-if="groupMembers.length === 0" class="text-sm text-gray-500">{{ t('matches.groupNoPlayers') }}</p>
-        </div>
-
-        <p v-else class="text-sm text-gray-500">{{ t('matches.selectGroupSeePlayers') }}</p>
-      </TransitionGroup>
-
+      <button class="px-4 py-2 rounded bg-violet-600 hover:bg-violet-700 text-white font-medium shrink-0"
+        @click="router.push({ name: 'create-match' })">
+        + {{ t('matches.create') }}
+      </button>
     </div>
 
-    <!-- Listado de partidos con transición -->
+    <!-- List of matches -->
     <TransitionGroup name="match" tag="div" class="space-y-3" appear>
       <h1 v-if="selectedGroup" class="text-2xl font-semibold">{{ t('matches.matchesTitle') }}</h1>
 


### PR DESCRIPTION
# UX: Separar creación de partidos y mejorar visualización

## Cambios principales

### Nueva página `/matches/new` (`CreateMatchPage.vue`)
- La lógica de creación de partidos (selector de grupo, fecha, checkboxes de jugadores) fue extraída de la vista de partidos a su propia página dedicada.
- Al crear el partido, redirige automáticamente a la lista.
- Si el usuario solo tiene un grupo, se preselecciona automáticamente.

### Vista de partidos simplificada (`MatchesPage.vue`)
- Eliminado el formulario de creación embebido; ahora muestra solo el selector de grupo y un botón "+ Crear partido".
- Si hay un solo grupo disponible, se selecciona automáticamente al cargar.

### Mejoras en `MatchCard`
- Formato de fecha actualizado: `es-AR`, 24 hs, sin segundos (ej: `4/3/2026, 19:00`).
- Badge de estado junto a la fecha: **"Próximo"** (viola) y **"Finalizado"** (gris).

### Botón volver en `MatchDetailPage`
- Se agregó un enlace "← Volver a partidos" en la parte superior.
